### PR TITLE
Add TODOs for improving LocalTesting and gateway jar handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+# TODO
+
+- Revise `LocalTesting` integration tests. Mirror the `BackPressureExample` environment but swap the custom consumer and back-pressure metrics with a pipeline built from FlinkDotNet, Apache Flink and Temporal. Tests should submit a real job and verify message flow and metrics rather than expecting submission failures.
+- Ensure tests handle the job lifecycle correctly. Current runs can report `COMPLETED` status, causing assertions to fail; update tests to expect the proper state or wait for completion.
+- Extend the FlinkDotNet Gateway so job submission automatically bundles all required JARs (IR runner, connectors and job artifacts). Remove the need for `FLINK_RUNNER_JAR_PATH` or manual build steps.
+- Add test coverage for the auto-bundled gateway path to guarantee the assembled JAR runs end-to-end without manual intervention.
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,26 @@
 # TODO
 
-- Revise `LocalTesting` integration tests. Mirror the `BackPressureExample` environment but swap the custom consumer and back-pressure metrics with a pipeline built from FlinkDotNet, Apache Flink and Temporal. Tests should submit a real job and verify message flow and metrics rather than expecting submission failures.
-- Ensure tests handle the job lifecycle correctly. Current runs can report `COMPLETED` status, causing assertions to fail; update tests to expect the proper state or wait for completion.
-- Extend the FlinkDotNet Gateway so job submission automatically bundles all required JARs (IR runner, connectors and job artifacts). Remove the need for `FLINK_RUNNER_JAR_PATH` or manual build steps.
-- Add test coverage for the auto-bundled gateway path to guarantee the assembled JAR runs end-to-end without manual intervention.
+## LocalTesting integration tests
+- Replace `Projects.BackPressure_AppHost` with a new host that provisions Kafka, Flink JobManager/TaskManager, Temporal server, and the `Flink.JobGateway` project.  The gateway must be started without `FLINK_RUNNER_JAR_PATH`.
+- Update `FlinkDotNetIntegrationTest`:
+  - Drop the branch that expects submission failure.
+  - After `Submit`, poll `GetJobStatusAsync` until the job is `RUNNING` or `FINISHED` before sending data.
+  - Produce to the input topic, consume from the output topic, and assert Flink metrics (`RecordsIn`, `RecordsOut`, `Checkpoints`) and Temporal workflow completions via `TemporalClient`.
+- Update `FlinkSqlIntegrationTest` to rely on the same host and automatic connector/jar bundling.  Validate end‑to‑end SQL execution and Temporal integration.
 
+## Gateway jar bundling
+- In `Flink.JobGateway/Services/FlinkJobManager.cs`, refactor `EnsureRunnerJarAsync`:
+  - Build `flink-ir-runner.jar` on demand (invoke Maven directly) when not present.
+  - Collect connector JARs from `/opt/flink/lib` or a configured path and stage them in a temp directory.
+  - Assemble a shaded JAR that combines the IR runner, connectors, and job artifacts, then upload via `/v1/jars/upload`.
+  - Remove dependency on `FLINK_RUNNER_JAR_PATH` and `scripts/build_runner.ps1`.
+
+## AppHost cleanup
+- Remove the explicit `FLINK_RUNNER_JAR_PATH` environment variable from `LocalTesting/BackPressure.AppHost/Program.cs`; gateway should determine paths internally.
+- Expose configuration for connector locations through the application model rather than env vars.
+
+## Job lifecycle handling
+- Tests should actively wait for terminal states instead of asserting that the job is not `COMPLETED`.  Implement a retry loop around `GetJobStatusAsync` with timeout.
+
+## Test coverage
+- Add an integration test that starts the app host with no prebuilt runner JAR or env vars, submits a job, and verifies that the gateway’s automatic bundling path produces a running job.


### PR DESCRIPTION
## Summary
- Add tasks to revise LocalTesting integration tests to use FlinkDotNet with Flink and Temporal
- Note need for automatic JAR bundling in the FlinkDotNet gateway and related test coverage

## Testing
- `dotnet test LocalTesting/LocalTesting.sln` *(fails: A compatible .NET SDK 9.0.100 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d113f2a48322a92678ba97f61eaf